### PR TITLE
fix floating hex string representation to set a proper tint color

### DIFF
--- a/build/phaser-spine.js
+++ b/build/phaser-spine.js
@@ -3075,7 +3075,7 @@ var PhaserSpine;
                     slotContainer.scale.y = bone.getWorldScaleX() * bone.worldSignY;
                     slotContainer.rotation = (bone.getWorldRotationX() - attachment.rotation) * Math.PI / 180;
                     slot.currentSprite.blendMode = slot.blendMode;
-                    slot.currentSprite.tint = parseInt(Phaser.Color.componentToHex(255 * slot.r) + Phaser.Color.componentToHex(255 * slot.g) + Phaser.Color.componentToHex(255 * slot.b), 16);
+                  slot.currentSprite.tint = parseInt(Phaser.Color.componentToHex(255 * slot.r).substring(0, 2) + Phaser.Color.componentToHex(255 * slot.g).substring(0, 2) + Phaser.Color.componentToHex(255 * slot.b).substring(0, 2), 16);
                 }
                 else if (type === spine.AttachmentType.weightedmesh || type === spine.AttachmentType.weightedlinkedmesh) {
                     if (!slot.currentMeshName || slot.currentMeshName !== attachment.name) {

--- a/build/phaser-spine.js
+++ b/build/phaser-spine.js
@@ -3026,6 +3026,16 @@ var PhaserSpine;
             }
             return 1;
         };
+
+      Spine.prototype.setTint = function (tint) {
+        this.globalTint = tint;
+        var slots = this.skeleton.slots;
+        for(var i = 0; i < slots.length; i++) {
+          var slot = slots[i];
+          slot.currentSprite.tint = tint;
+        }
+      };
+
         Spine.prototype.update = function (dt) {
             if (dt === undefined) {
                 return;
@@ -3075,7 +3085,8 @@ var PhaserSpine;
                     slotContainer.scale.y = bone.getWorldScaleX() * bone.worldSignY;
                     slotContainer.rotation = (bone.getWorldRotationX() - attachment.rotation) * Math.PI / 180;
                     slot.currentSprite.blendMode = slot.blendMode;
-                  slot.currentSprite.tint = parseInt(Phaser.Color.componentToHex(255 * slot.r).substring(0, 2) + Phaser.Color.componentToHex(255 * slot.g).substring(0, 2) + Phaser.Color.componentToHex(255 * slot.b).substring(0, 2), 16);
+                    if(!this.globalTint)
+                        slot.currentSprite.tint = parseInt(Phaser.Color.componentToHex(255 * slot.r).substring(0, 2) + Phaser.Color.componentToHex(255 * slot.g).substring(0, 2) + Phaser.Color.componentToHex(255 * slot.b).substring(0, 2), 16);
                 }
                 else if (type === spine.AttachmentType.weightedmesh || type === spine.AttachmentType.weightedlinkedmesh) {
                     if (!slot.currentMeshName || slot.currentMeshName !== attachment.name) {


### PR DESCRIPTION
Issue - fix floating hex string representation to set a proper tint color
if spine animation tweens the tint of slots, colors were not being updated properly in client

Feature - add global tint ability (useful when we have a white colored spine animation so we can set a global tint value to override the common logic in update method and have a custom colored spine animation)